### PR TITLE
Change binomial input structure

### DIFF
--- a/src/regmod/composite_models/base.py
+++ b/src/regmod/composite_models/base.py
@@ -123,9 +123,6 @@ class BaseModel(NodeModel):
             Data frame with the offset.
         """
         df = df.copy() if copy else df
-        if self.mtype == "binomial":
-            df[self.data.col_offset] = 0.0
-            return df
         if self.col_value in df:
             df[self.data.col_offset] = link_funs[self.mtype](df[self.col_value])
         return df

--- a/src/regmod/models/binomial.py
+++ b/src/regmod/models/binomial.py
@@ -16,28 +16,19 @@ class BinomialModel(Model):
     default_param_specs = {"p": {"inv_link": "expit"}}
 
     def __init__(self, data: Data, **kwargs):
-        if not np.all(data.obs >= 0):
-            raise ValueError("Binomial model requires observations to be non-negative.")
-        if len(data.col_obs) != 2:
-            raise ValueError("Binomial model need 2 columns of observations, "
-                             "one for number of events, one for sample size.")
-        if any(np.diff(data.get_cols(data.col_obs), axis=1) < 0):
-            raise ValueError("Binomial model requires number of events less or equal than sample size.")
-
-        self.obs_1s = data.get_cols(data.col_obs[0])
-        self.obs_0s = np.diff(data.get_cols(data.col_obs), axis=1).ravel()
-        self.obs_sample_sizes = data.get_cols(data.col_obs[1])
-
+        if not np.all((data.obs >= 0) & (data.obs <= 1)):
+            raise ValueError("Binomial model requires observations to be "
+                             "between zero and one.")
         super().__init__(data, **kwargs)
 
     def nll(self, params: List[ndarray]) -> ndarray:
-        return -(self.obs_1s*np.log(params[0]) + self.obs_0s*np.log(1.0 - params[0]))
+        return -(self.data.obs*np.log(params[0]) + (1 - self.data.obs)*np.log(1.0 - params[0]))
 
     def dnll(self, params: List[ndarray]) -> List[ndarray]:
-        return [-(self.obs_1s/params[0] - self.obs_0s/(1.0 - params[0]))]
+        return [-(self.data.obs/params[0] - (1 - self.data.obs)/(1.0 - params[0]))]
 
     def d2nll(self, params: List[ndarray]) -> List[List[ndarray]]:
-        return [[self.obs_1s/params[0]**2 + self.obs_0s/(1.0 - params[0])**2]]
+        return [[self.data.obs/params[0]**2 + (1 - self.data.obs)/(1.0 - params[0])**2]]
 
     def get_ui(self, params: List[ndarray], bounds: Tuple[float, float]) -> ndarray:
         p = params[0]

--- a/tests/test_binomialmodel.py
+++ b/tests/test_binomialmodel.py
@@ -18,15 +18,17 @@ from regmod.utils import SplineSpecs
 @pytest.fixture
 def data():
     num_obs = 5
-    obs_1s = np.random.rand(num_obs)*10
+    obs = np.random.rand(num_obs)
+    sample_size = np.random.poisson(lam=5, size=num_obs)
     df = pd.DataFrame({
-        "obs_1s": obs_1s,
-        "obs_sample_sizes": obs_1s + 1.0,
+        "obs": obs,
+        "sample_size": sample_size,
         "cov0": np.random.randn(num_obs),
         "cov1": np.random.randn(num_obs)
     })
-    return Data(col_obs=["obs_1s", "obs_sample_sizes"],
+    return Data(col_obs="obs",
                 col_covs=["cov0", "cov1"],
+                col_weights="sample_size",
                 df=df)
 
 


### PR DESCRIPTION
In this PR, we change to use `weights` for sample size information, instead of two columns for observation.