### PR TITLE
revert to previous way of assigning x0 default in optimizers

### DIFF
--- a/src/regmod/optimizer.py
+++ b/src/regmod/optimizer.py
@@ -30,7 +30,7 @@ def scipy_optimize(model: "Model",
     NDArray
         Optimal solution.
     """
-    x0 = x0 or np.zeros(model.size)
+    x0 = np.zeros(model.size) if x0 is None else x0
     bounds = model.uvec.T
     constraints = [LinearConstraint(
         model.linear_umat,
@@ -55,7 +55,7 @@ def scipy_optimize(model: "Model",
 def msca_optimize(model: "Model",
                   x0: Optional[NDArray] = None,
                   options: Optional[Dict] = None) -> NDArray:
-    x0 = x0 or np.zeros(model.size)
+    x0 = np.zeros(model.size) if x0 is None else x0
     options = options or {}
 
     if model.cmat.size == 0:


### PR DESCRIPTION
This fixes the bug when x0 is passed to the optimizer (which always happens when using trimming() function, see line 129).