### PR TITLE
move conversion to JAX data structures from constructor to attach_df

### DIFF
--- a/src/regmod/models/tobit.py
+++ b/src/regmod/models/tobit.py
@@ -78,7 +78,16 @@ class TobitModel(Model):
             default_link = self.default_param_specs[param_name]["inv_link"]
             self.params[ii].inv_link = default_link
 
-        # Use JAX data structures
+    def attach_df(self, df: DataFrame) -> None:
+        """Extract training data from data frame.
+
+        Parameters
+        ----------
+        df : DataFrame
+            Training data.
+
+        """
+        super().attach_df(df)
         self.mat = [jnp.asarray(mat) for mat in self.mat]
         self.uvec = jnp.asarray(self.uvec)
         self.gvec = jnp.asarray(self.gvec)


### PR DESCRIPTION
Exceptions raised in constructor when creating a model with data.is_empty() is true, because constructor converts data structures (e.g., self.mat) to JAX data structures before said structures have been created. Moved the JAX conversion into attach_df(), where it should have been in the first place.