### PR TITLE
Copy the prediction dataframe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "regmod"
-version = "0.0.8"
+version = "0.0.9"
 description = "General regression models"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/regmod/models/model.py
+++ b/src/regmod/models/model.py
@@ -613,6 +613,8 @@ class Model:
         """
         if df is None:
             df = self.data.df.copy()
+        else:
+            df = df.copy()
         data = self.data.copy()
         data.attach_df(df)
 


### PR DESCRIPTION
This PR aims to solve a warning message generated by `pandas` when tries to predict using the `tobit` class.
```
regmod/src/regmod/models/tobit.py:247: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame.
  Try using .loc[row_indexer,col_indexer] = value instead
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
    df["mu_censored"] = df["mu"]
```
This issue is generated because we try to modify a slice or copy of the original data frame. To solve this we need to copy the original data frame passed into the `predict` function in the parent class.