### PR TITLE
Add canonical models and Pearson residuals

### DIFF
--- a/src/regmod/models/__init__.py
+++ b/src/regmod/models/__init__.py
@@ -3,7 +3,7 @@ Models
 """
 
 from .binomial import BinomialModel, CanonicalBinomialModel, create_binomial_model
-from .gaussian import GaussianModel
+from .gaussian import CanonicalGaussianModel, GaussianModel, create_gaussian_model
 from .model import Model
 from .negativebinomial import NegativeBinomialModel
 from .pogit import PogitModel

--- a/src/regmod/models/__init__.py
+++ b/src/regmod/models/__init__.py
@@ -10,3 +10,20 @@ from .pogit import PogitModel
 from .poisson import CanonicalPoissonModel, PoissonModel, create_poisson_model
 from .tobit import TobitModel
 from .weibull import WeibullModel
+
+__all__ = [
+    "BinomialModel",
+    "CanonicalBinomialModel",
+    "create_binomial_model",
+    "CanonicalGaussianModel",
+    "GaussianModel",
+    "create_gaussian_model",
+    "Model",
+    "NegativeBinomialModel",
+    "PogitModel",
+    "CanonicalPoissonModel",
+    "PoissonModel",
+    "create_poisson_model",
+    "TobitModel",
+    "WeibullModel",
+]

--- a/src/regmod/models/__init__.py
+++ b/src/regmod/models/__init__.py
@@ -7,6 +7,6 @@ from .gaussian import CanonicalGaussianModel, GaussianModel, create_gaussian_mod
 from .model import Model
 from .negativebinomial import NegativeBinomialModel
 from .pogit import PogitModel
-from .poisson import PoissonModel
+from .poisson import CanonicalPoissonModel, PoissonModel, create_poisson_model
 from .tobit import TobitModel
 from .weibull import WeibullModel

--- a/src/regmod/models/__init__.py
+++ b/src/regmod/models/__init__.py
@@ -2,11 +2,11 @@
 Models
 """
 
-from .model import Model
+from .binomial import BinomialModel, CanonicalBinomialModel, create_binomial_model
 from .gaussian import GaussianModel
-from .poisson import PoissonModel
-from .binomial import BinomialModel
+from .model import Model
 from .negativebinomial import NegativeBinomialModel
 from .pogit import PogitModel
-from .weibull import WeibullModel
+from .poisson import PoissonModel
 from .tobit import TobitModel
+from .weibull import WeibullModel

--- a/src/regmod/models/binomial.py
+++ b/src/regmod/models/binomial.py
@@ -166,9 +166,7 @@ class BinomialModel(Model):
         return jacobian2
 
     def get_pearson_residuals(self, coefs: NDArray) -> NDArray:
-        z = np.exp(self.get_lin_param(coefs))
-
-        pred = z / (1 + z)
+        pred = self.params[0].get_param(coefs, self.data, mat=self.mat[0])
         pred_sd = np.sqrt(pred * (1 - pred) / self.data.weights)
 
         return (self.data.obs - pred) / pred_sd

--- a/src/regmod/models/binomial.py
+++ b/src/regmod/models/binomial.py
@@ -10,7 +10,7 @@ from regmod.data import Data
 from regmod.optimizer import msca_optimize
 
 from .model import Model
-from .utils import model_post_init
+from .utils import get_params, model_post_init
 
 
 class BinomialModel(Model):
@@ -55,42 +55,115 @@ class BinomialModel(Model):
         return self.hmat
 
     def objective(self, coefs: NDArray) -> float:
-        weights = self.data.weights * self.data.trim_weights
-        y = self.get_lin_param(coefs)
+        """Objective function.
+        Parameters
+        ----------
+        coefs : NDArray
+            Given coefficients.
 
-        prior_obj = self.objective_from_gprior(coefs)
-        likli_obj = weights.dot(np.log(1 + np.exp(-y)) + (1 - self.data.obs) * y)
-        return prior_obj + likli_obj
+        Returns
+        -------
+        float
+            Objective value.
+
+        """
+        inv_link = self.params[0].inv_link
+        lin_param = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
+        param = inv_link.fun(lin_param)
+
+        weights = self.data.weights * self.data.trim_weights
+        obj_param = -weights * (
+            self.data.obs * np.log(param) + (1 - self.data.obs) * np.log(1 - param)
+        )
+        return obj_param.sum() + self.objective_from_gprior(coefs)
 
     def gradient(self, coefs: NDArray) -> NDArray:
-        mat = self.mat[0]
-        weights = self.data.weights * self.data.trim_weights
-        z = np.exp(self.get_lin_param(coefs))
+        """Gradient function.
 
-        prior_grad = self.gradient_from_gprior(coefs)
-        likli_grad = mat.T.dot(weights * (z / (1 + z) - self.data.obs))
-        return prior_grad + likli_grad
+        Parameters
+        ----------
+        coefs : NDArray
+            Given coefficients.
+
+        Returns
+        -------
+        NDArray
+            Gradient vector.
+
+        """
+        mat = self.mat[0]
+        inv_link = self.params[0].inv_link
+        lin_param = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
+        param = inv_link.fun(lin_param)
+        dparam = inv_link.dfun(lin_param)
+
+        weights = self.data.weights * self.data.trim_weights
+        grad_param = weights * (
+            (param - self.data.obs) / (param * (1 - param)) * dparam
+        )
+
+        return mat.T.dot(grad_param) + self.gradient_from_gprior(coefs)
 
     def hessian(self, coefs: NDArray) -> NDArray:
+        """Hessian function.
+
+        Parameters
+        ----------
+        coefs : NDArray
+            Given coefficients.
+
+        Returns
+        -------
+        NDArray
+            Hessian matrix.
+
+        """
         mat = self.mat[0]
+        inv_link = self.params[0].inv_link
+        lin_param = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
+        param = inv_link.fun(lin_param)
+        dparam = inv_link.dfun(lin_param)
+        d2param = inv_link.d2fun(lin_param)
+
         weights = self.data.weights * self.data.trim_weights
-        z = np.exp(self.get_lin_param(coefs))
-        likli_hess_scale = weights * (z / ((1 + z) ** 2))
+        hess_param = weights * (
+            (self.data.obs / param**2 + (1 - self.data.obs) / (1 - param) ** 2)
+            * dparam**2
+            + (param - self.data.obs) / (param * (1 - param)) * d2param
+        )
 
-        likli_hess_right = mat.scale_rows(likli_hess_scale)
-        likli_hess = mat.T.dot(likli_hess_right)
-
-        return self.hessian_from_gprior() + likli_hess
+        scaled_mat = mat.scale_rows(hess_param)
+        hess_mat = mat.T.dot(scaled_mat)
+        hess_mat_gprior = type(hess_mat)(self.hessian_from_gprior())
+        return hess_mat + hess_mat_gprior
 
     def jacobian2(self, coefs: NDArray) -> NDArray:
-        mat = self.mat[0]
-        weights = self.data.weights * self.data.trim_weights
-        z = np.exp(self.get_lin_param(coefs))
-        likli_jac_scale = weights * (z / (1 + z) - self.data.obs)
+        """Jacobian function.
 
-        likli_jac = mat.T.scale_cols(likli_jac_scale)
-        likli_jac2 = likli_jac.dot(likli_jac.T)
-        return self.hessian_from_gprior() + likli_jac2
+        Parameters
+        ----------
+        coefs : NDArray
+            Given coefficients.
+
+        Returns
+        -------
+        NDArray
+            Jacobian matrix.
+
+        """
+        mat = self.mat[0]
+        inv_link = self.params[0].inv_link
+        lin_param = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
+        param = inv_link.fun(lin_param)
+        dparam = inv_link.dfun(lin_param)
+        weights = self.data.weights * self.data.trim_weights
+        grad_param = weights * (
+            (param - self.data.obs) / (param * (1 - param)) * dparam
+        )
+        jacobian = mat.T.scale_cols(grad_param)
+        hess_mat_gprior = type(jacobian)(self.hessian_from_gprior())
+        jacobian2 = jacobian.dot(jacobian.T) + hess_mat_gprior
+        return jacobian2
 
     def get_pearson_residuals(self, coefs: NDArray) -> NDArray:
         z = np.exp(self.get_lin_param(coefs))
@@ -132,3 +205,62 @@ class BinomialModel(Model):
         p = params[0]
         n = self.obs_sample_sizes
         return [binom.ppf(bounds[0], n=n, p=p), binom.ppf(bounds[1], n=n, p=p)]
+
+
+class CanonicalBinomialModel(BinomialModel):
+    def __init__(self, data: Data, **kwargs):
+        super().__init__(data, **kwargs)
+        if self.params[0].inv_link.name != "expit":
+            raise ValueError(
+                "Canonical Binomial model requires inverse link to be expit."
+            )
+
+    def objective(self, coefs: NDArray) -> float:
+        weights = self.data.weights * self.data.trim_weights
+        y = self.get_lin_param(coefs)
+
+        prior_obj = self.objective_from_gprior(coefs)
+        likli_obj = weights.dot(np.log(1 + np.exp(-y)) + (1 - self.data.obs) * y)
+        return prior_obj + likli_obj
+
+    def gradient(self, coefs: NDArray) -> NDArray:
+        mat = self.mat[0]
+        weights = self.data.weights * self.data.trim_weights
+        z = np.exp(self.get_lin_param(coefs))
+
+        prior_grad = self.gradient_from_gprior(coefs)
+        likli_grad = mat.T.dot(weights * (z / (1 + z) - self.data.obs))
+        return prior_grad + likli_grad
+
+    def hessian(self, coefs: NDArray) -> NDArray:
+        mat = self.mat[0]
+        weights = self.data.weights * self.data.trim_weights
+        z = np.exp(self.get_lin_param(coefs))
+        likli_hess_scale = weights * (z / ((1 + z) ** 2))
+
+        likli_hess_right = mat.scale_rows(likli_hess_scale)
+        likli_hess = mat.T.dot(likli_hess_right)
+
+        return self.hessian_from_gprior() + likli_hess
+
+    def jacobian2(self, coefs: NDArray) -> NDArray:
+        mat = self.mat[0]
+        weights = self.data.weights * self.data.trim_weights
+        z = np.exp(self.get_lin_param(coefs))
+        likli_jac_scale = weights * (z / (1 + z) - self.data.obs)
+
+        likli_jac = mat.T.scale_cols(likli_jac_scale)
+        likli_jac2 = likli_jac.dot(likli_jac.T)
+        return self.hessian_from_gprior() + likli_jac2
+
+
+def create_binomial_model(data: Data, **kwargs) -> BinomialModel:
+    params = get_params(
+        params=kwargs.get("params"),
+        param_specs=kwargs.get("param_specs"),
+        default_param_specs=BinomialModel.default_param_specs,
+    )
+
+    if params[0].inv_link.name == "expit":
+        return CanonicalBinomialModel(data, params=params)
+    return BinomialModel(data, params=params)

--- a/src/regmod/models/binomial.py
+++ b/src/regmod/models/binomial.py
@@ -255,3 +255,7 @@ def create_binomial_model(data: Data, **kwargs) -> BinomialModel:
     if params[0].inv_link.name == "expit":
         return CanonicalBinomialModel(data, params=params)
     return BinomialModel(data, params=params)
+
+
+for key in ["param_names", "default_param_specs"]:
+    setattr(create_binomial_model, key, getattr(BinomialModel, key))

--- a/src/regmod/models/gaussian.py
+++ b/src/regmod/models/gaussian.py
@@ -32,13 +32,6 @@ class GaussianModel(Model):
     def hessian_from_gprior(self) -> Matrix:
         return self.hmat
 
-    def get_lin_param(self, coefs: NDArray) -> NDArray:
-        mat = self.mat[0]
-        lin_param = mat.dot(coefs)
-        if self.params[0].offset is not None:
-            lin_param += self.data.get_cols(self.params[0].offset)
-        return lin_param
-
     def objective(self, coefs: NDArray) -> float:
         """Objective function.
         Parameters
@@ -184,7 +177,7 @@ class CanonicalGaussianModel(GaussianModel):
 
     def objective(self, coefs: NDArray) -> float:
         weights = self.data.weights * self.data.trim_weights
-        y = self.get_lin_param(coefs)
+        y = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
 
         prior_obj = self.objective_from_gprior(coefs)
         likli_obj = 0.5 * weights.dot((y - self.data.obs) ** 2)
@@ -193,7 +186,7 @@ class CanonicalGaussianModel(GaussianModel):
     def gradient(self, coefs: NDArray) -> NDArray:
         mat = self.mat[0]
         weights = self.data.weights * self.data.trim_weights
-        y = self.get_lin_param(coefs)
+        y = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
 
         prior_grad = self.gradient_from_gprior(coefs)
         likli_grad = mat.T.dot(weights * (y - self.data.obs))
@@ -213,7 +206,7 @@ class CanonicalGaussianModel(GaussianModel):
     def jacobian2(self, coefs: NDArray) -> NDArray:
         mat = self.mat[0]
         weights = self.data.weights * self.data.trim_weights
-        y = self.get_lin_param(coefs)
+        y = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
         likli_jac_scale = weights * (y - self.data.obs)
 
         likli_jac = mat.T.scale_cols(likli_jac_scale)

--- a/src/regmod/models/gaussian.py
+++ b/src/regmod/models/gaussian.py
@@ -140,6 +140,12 @@ class GaussianModel(Model):
         jacobian2 = jacobian.dot(jacobian.T) + hess_mat_gprior
         return jacobian2
 
+    def get_pearson_residuals(self, coefs: NDArray) -> NDArray:
+        pred = self.params[0].get_param(coefs, self.data, mat=self.mat[0])
+        pred_sd = 1.0 / np.sqrt(self.data.weights)
+
+        return (self.data.obs - pred) / pred_sd
+
     def fit(self, optimizer: Callable = msca_optimize, **optimizer_options):
         """Fit function.
 

--- a/src/regmod/models/gaussian.py
+++ b/src/regmod/models/gaussian.py
@@ -5,8 +5,8 @@ Gaussian Model
 import numpy as np
 from scipy.stats import norm
 
+from regmod._typing import Callable, DataFrame, Matrix, NDArray
 from regmod.optimizer import msca_optimize
-from regmod._typing import Callable, NDArray, DataFrame
 
 from .model import Model
 from .utils import model_post_init
@@ -18,9 +18,18 @@ class GaussianModel(Model):
 
     def attach_df(self, df: DataFrame):
         super().attach_df(df)
-        self.mat[0], self.cmat, self.cvec = model_post_init(
-            self.mat[0], self.uvec, self.linear_umat, self.linear_uvec
+        self.mat[0], self.cmat, self.cvec, self.hmat = model_post_init(
+            self.mat[0],
+            self.uvec,
+            self.linear_umat,
+            self.linear_uvec,
+            self.gvec,
+            self.linear_gmat,
+            self.linear_gvec,
         )
+
+    def hessian_from_gprior(self) -> Matrix:
+        return self.hmat
 
     def objective(self, coefs: NDArray) -> float:
         """Objective function.

--- a/src/regmod/models/gaussian.py
+++ b/src/regmod/models/gaussian.py
@@ -224,3 +224,7 @@ def create_gaussian_model(data: Data, **kwargs) -> GaussianModel:
     if params[0].inv_link.name == "identity":
         return CanonicalGaussianModel(data, params=params)
     return GaussianModel(data, params=params)
+
+
+for key in ["param_names", "default_param_specs"]:
+    setattr(create_gaussian_model, key, getattr(GaussianModel, key))

--- a/src/regmod/models/model.py
+++ b/src/regmod/models/model.py
@@ -8,6 +8,7 @@ from scipy.sparse import csc_matrix
 
 from regmod._typing import Callable, DataFrame, Matrix, NDArray
 from regmod.data import Data
+from regmod.models.utils import get_params
 from regmod.optimizer import scipy_optimize
 from regmod.parameter import Parameter
 from regmod.utils import sizes_to_slices
@@ -131,23 +132,9 @@ class Model:
         params: list[Parameter] | None = None,
         param_specs: dict[str, dict] | None = None,
     ):
-        if params is None and param_specs is None:
-            raise ValueError("Must provide `params` or `param_specs`")
-
-        if params is not None:
-            param_dict = {param.name: param for param in params}
-            self.params = [param_dict[param_name] for param_name in self.param_names]
-        else:
-            self.params = [
-                Parameter(
-                    param_name,
-                    **{
-                        **self.default_param_specs[param_name],
-                        **param_specs[param_name],
-                    },
-                )
-                for param_name in self.param_names
-            ]
+        params = get_params(params, param_specs, self.default_param_specs)
+        param_dict = {param.name: param for param in params}
+        self.params = [param_dict[param_name] for param_name in self.param_names]
 
         self.data = data
         if not self.data.is_empty():

--- a/src/regmod/models/model.py
+++ b/src/regmod/models/model.py
@@ -3,15 +3,14 @@ Model module
 """
 
 import numpy as np
-
 from scipy.linalg import block_diag
 from scipy.sparse import csc_matrix
 
+from regmod._typing import Callable, DataFrame, Matrix, NDArray
 from regmod.data import Data
 from regmod.optimizer import scipy_optimize
 from regmod.parameter import Parameter
 from regmod.utils import sizes_to_slices
-from regmod._typing import Callable, NDArray, DataFrame, Matrix
 
 
 class Model:
@@ -428,6 +427,9 @@ class Model:
         NDArray
             An array with uncertainty interval for each observation.
         """
+        raise NotImplementedError()
+
+    def get_pearson_residuals(self, coefs: NDArray) -> NDArray:
         raise NotImplementedError()
 
     def detect_outliers(self, coefs: NDArray, bounds: tuple[float, float]) -> NDArray:

--- a/src/regmod/models/poisson.py
+++ b/src/regmod/models/poisson.py
@@ -142,6 +142,12 @@ class PoissonModel(Model):
         jacobian2 = jacobian.dot(jacobian.T) + hess_mat_gprior
         return jacobian2
 
+    def get_pearson_residuals(self, coefs: NDArray) -> NDArray:
+        pred = self.params[0].get_param(coefs, self.data, mat=self.mat[0])
+        pred_sd = np.sqrt(pred * self.data.weights)
+
+        return (self.data.obs - pred) / pred_sd
+
     def fit(self, optimizer: Callable = msca_optimize, **optimizer_options):
         """Fit function.
 

--- a/src/regmod/models/poisson.py
+++ b/src/regmod/models/poisson.py
@@ -222,3 +222,7 @@ def create_poisson_model(data: Data, **kwargs) -> PoissonModel:
     if params[0].inv_link.name == "exp":
         return CanonicalPoissonModel(data, params=params)
     return PoissonModel(data, params=params)
+
+
+for key in ["param_names", "default_param_specs"]:
+    setattr(create_poisson_model, key, getattr(PoissonModel, key))

--- a/src/regmod/models/poisson.py
+++ b/src/regmod/models/poisson.py
@@ -5,9 +5,9 @@ Poisson Model
 import numpy as np
 from scipy.stats import poisson
 
+from regmod._typing import Callable, DataFrame, NDArray
 from regmod.data import Data
 from regmod.optimizer import msca_optimize
-from regmod._typing import Callable, NDArray, DataFrame
 
 from .model import Model
 from .utils import model_post_init
@@ -24,9 +24,18 @@ class PoissonModel(Model):
 
     def attach_df(self, df: DataFrame):
         super().attach_df(df)
-        self.mat[0], self.cmat, self.cvec = model_post_init(
-            self.mat[0], self.uvec, self.linear_umat, self.linear_uvec
+        self.mat[0], self.cmat, self.cvec, self.hmat = model_post_init(
+            self.mat[0],
+            self.uvec,
+            self.linear_umat,
+            self.linear_uvec,
+            self.gvec,
+            self.linear_gmat,
+            self.linear_gvec,
         )
+
+    def hessian_from_gprior(self):
+        return self.hmat
 
     def objective(self, coefs: NDArray) -> float:
         """Objective function.

--- a/src/regmod/models/poisson.py
+++ b/src/regmod/models/poisson.py
@@ -34,13 +34,6 @@ class PoissonModel(Model):
             self.linear_gvec,
         )
 
-    def get_lin_param(self, coefs: NDArray) -> NDArray:
-        mat = self.mat[0]
-        lin_param = mat.dot(coefs)
-        if self.params[0].offset is not None:
-            lin_param += self.data.get_cols(self.params[0].offset)
-        return lin_param
-
     def hessian_from_gprior(self):
         return self.hmat
 
@@ -180,7 +173,7 @@ class CanonicalPoissonModel(PoissonModel):
 
     def objective(self, coefs: NDArray) -> float:
         weights = self.data.weights * self.data.trim_weights
-        y = self.get_lin_param(coefs)
+        y = self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0])
         z = np.exp(y)
 
         prior_obj = self.objective_from_gprior(coefs)
@@ -190,7 +183,7 @@ class CanonicalPoissonModel(PoissonModel):
     def gradient(self, coefs: NDArray) -> NDArray:
         mat = self.mat[0]
         weights = self.data.weights * self.data.trim_weights
-        z = np.exp(self.get_lin_param(coefs))
+        z = np.exp(self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0]))
 
         prior_grad = self.gradient_from_gprior(coefs)
         likli_grad = mat.T.dot(weights * (z - self.data.obs))
@@ -199,7 +192,7 @@ class CanonicalPoissonModel(PoissonModel):
     def hessian(self, coefs: NDArray) -> Matrix:
         mat = self.mat[0]
         weights = self.data.weights * self.data.trim_weights
-        z = np.exp(self.get_lin_param(coefs))
+        z = np.exp(self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0]))
         likli_hess_scale = weights * z
 
         prior_hess = self.hessian_from_gprior()
@@ -211,7 +204,7 @@ class CanonicalPoissonModel(PoissonModel):
     def jacobian2(self, coefs: NDArray) -> NDArray:
         mat = self.mat[0]
         weights = self.data.weights * self.data.trim_weights
-        z = np.exp(self.get_lin_param(coefs))
+        z = np.exp(self.params[0].get_lin_param(coefs, self.data, mat=self.mat[0]))
         likli_jac_scale = weights * (z - self.data.obs)
 
         likli_jac = mat.T.scale_cols(likli_jac_scale)

--- a/src/regmod/models/utils.py
+++ b/src/regmod/models/utils.py
@@ -3,6 +3,7 @@ from msca.linalg.matrix import asmatrix
 from scipy.sparse import csc_matrix
 
 from regmod._typing import Matrix, NDArray
+from regmod.parameter import Parameter
 
 
 def model_post_init(
@@ -48,3 +49,24 @@ def model_post_init(
 
     hmat = gmat.T.scale_cols(1.0 / gvec[1] ** 2).dot(gmat)
     return mat, cmat, cvec, hmat
+
+
+def get_params(
+    params: list[Parameter] | None = None,
+    param_specs: dict[str, dict] | None = None,
+    default_param_specs: dict[str, dict] | None = None,
+) -> list[Parameter]:
+    if params is None and param_specs is None:
+        raise ValueError("Please provide `params` or `param_specs`")
+
+    if params is not None:
+        return params
+
+    default_param_specs = default_param_specs or {}
+    param_specs = {
+        key: {**default_param_specs.get(key, {}), **value}
+        for key, value in param_specs.items()
+    }
+
+    params = [Parameter(key, **value) for key, value in param_specs.items()]
+    return params

--- a/tests/test_poissonmodel.py
+++ b/tests/test_poissonmodel.py
@@ -1,15 +1,19 @@
 """
 Test Poisson Model
 """
+
 import numpy as np
 import pandas as pd
 import pytest
-
 from regmod.data import Data
 from regmod.function import fun_dict
-from regmod.models import PoissonModel
-from regmod.prior import (GaussianPrior, SplineGaussianPrior,
-                          SplineUniformPrior, UniformPrior)
+from regmod.models import create_poisson_model
+from regmod.prior import (
+    GaussianPrior,
+    SplineGaussianPrior,
+    SplineUniformPrior,
+    UniformPrior,
+)
 from regmod.utils import SplineSpecs
 from regmod.variable import SplineVariable, Variable
 
@@ -19,27 +23,27 @@ from regmod.variable import SplineVariable, Variable
 @pytest.fixture
 def data():
     num_obs = 5
-    df = pd.DataFrame({
-        "obs": np.random.rand(num_obs)*10,
-        "cov0": np.random.randn(num_obs),
-        "cov1": np.random.randn(num_obs)
-    })
-    return Data(col_obs="obs",
-                col_covs=["cov0", "cov1"],
-                df=df)
+    df = pd.DataFrame(
+        {
+            "obs": np.random.rand(num_obs) * 10,
+            "cov0": np.random.randn(num_obs),
+            "cov1": np.random.randn(num_obs),
+        }
+    )
+    return Data(col_obs="obs", col_covs=["cov0", "cov1"], df=df)
 
 
 @pytest.fixture
 def wrong_data():
     num_obs = 5
-    df = pd.DataFrame({
-        "obs": np.random.randn(num_obs),
-        "cov0": np.random.randn(num_obs),
-        "cov1": np.random.randn(num_obs)
-    })
-    return Data(col_obs="obs",
-                col_covs=["cov0", "cov1"],
-                df=df)
+    df = pd.DataFrame(
+        {
+            "obs": np.random.randn(num_obs),
+            "cov0": np.random.randn(num_obs),
+            "cov1": np.random.randn(num_obs),
+        }
+    )
+    return Data(col_obs="obs", col_covs=["cov0", "cov1"], df=df)
 
 
 @pytest.fixture
@@ -54,9 +58,9 @@ def uprior():
 
 @pytest.fixture
 def spline_specs():
-    return SplineSpecs(knots=np.linspace(0.0, 1.0, 5),
-                       degree=3,
-                       knots_type="rel_domain")
+    return SplineSpecs(
+        knots=np.linspace(0.0, 1.0, 5), degree=3, knots_type="rel_domain"
+    )
 
 
 @pytest.fixture
@@ -71,20 +75,21 @@ def spline_uprior():
 
 @pytest.fixture
 def var_cov0(gprior, uprior):
-    return Variable(name="cov0",
-                    priors=[gprior, uprior])
+    return Variable(name="cov0", priors=[gprior, uprior])
 
 
 @pytest.fixture
 def var_cov1(spline_gprior, spline_uprior, spline_specs):
-    return SplineVariable(name="cov1",
-                          spline_specs=spline_specs,
-                          priors=[spline_gprior, spline_uprior])
+    return SplineVariable(
+        name="cov1", spline_specs=spline_specs, priors=[spline_gprior, spline_uprior]
+    )
 
 
 @pytest.fixture
 def model(data, var_cov0, var_cov1):
-    return PoissonModel(data, param_specs={"lam": {"variables": [var_cov0, var_cov1]}})
+    return create_poisson_model(
+        data, param_specs={"lam": {"variables": [var_cov0, var_cov1]}}
+    )
 
 
 def test_model_size(model, var_cov0, var_cov1):
@@ -124,7 +129,7 @@ def test_model_gradient(model, inv_link):
     tr_grad = np.zeros(model.size)
     for i in range(model.size):
         coefs_c[i] += 1e-16j
-        tr_grad[i] = model.objective(coefs_c).imag/1e-16
+        tr_grad[i] = model.objective(coefs_c).imag / 1e-16
         coefs_c[i] -= 1e-16j
     assert np.allclose(my_grad, tr_grad)
 
@@ -139,7 +144,7 @@ def test_model_hessian(model, inv_link):
     for i in range(model.size):
         for j in range(model.size):
             coefs_c[j] += 1e-16j
-            tr_hess[i][j] = model.gradient(coefs_c).imag[i]/1e-16
+            tr_hess[i][j] = model.gradient(coefs_c).imag[i] / 1e-16
             coefs_c[j] -= 1e-16j
 
     assert np.allclose(my_hess, tr_hess)
@@ -147,7 +152,9 @@ def test_model_hessian(model, inv_link):
 
 def test_wrong_data(wrong_data, var_cov0, var_cov1):
     with pytest.raises(ValueError):
-        PoissonModel(wrong_data, param_specs={"lam": {"variables": [var_cov0, var_cov1]}})
+        create_poisson_model(
+            wrong_data, param_specs={"lam": {"variables": [var_cov0, var_cov1]}}
+        )
 
 
 def test_get_ui(model):
@@ -160,16 +167,18 @@ def test_get_ui(model):
 
 def test_model_no_variables():
     num_obs = 5
-    df = pd.DataFrame({
-        "obs": np.random.rand(num_obs)*10,
-        "offset": np.ones(num_obs),
-    })
+    df = pd.DataFrame(
+        {
+            "obs": np.random.rand(num_obs) * 10,
+            "offset": np.ones(num_obs),
+        }
+    )
     data = Data(
         col_obs="obs",
         col_offset="offset",
         df=df,
     )
-    model = PoissonModel(data, param_specs={"lam": {"offset": "offset"}})
+    model = create_poisson_model(data, param_specs={"lam": {"offset": "offset"}})
     coefs = np.array([])
     grad = model.gradient(coefs)
     hessian = model.hessian(coefs)


### PR DESCRIPTION
## Description

In this PR, we mainly add changes for the three main models, `GaussianModel`, `BinomialModel` and `PoissonModel`

* Add prior hessian computation in `models.utils.model_post_init`
* Add canonical models
* Add constructor to dynamically determine which type of model to create

## Remark

* This is patch for the current version, moving forward we should prioritize consolidate with `0.2.*`
* We probably should introduce a `Likelihood` class just like in `kreg`
* At the lower level we should create a unified array interface with potential backend as numpy array, jax array or scipy sparse array